### PR TITLE
bug-fix: style.width and style.height message log

### DIFF
--- a/lib/src/view/impl/web.dart
+++ b/lib/src/view/impl/web.dart
@@ -350,6 +350,8 @@ class _WebViewXState extends State<WebViewX> {
       ..style.border = 'none'
       ..width = widget.width.toInt().toString()
       ..height = widget.height.toInt().toString()
+      ..style.width = "100%"
+      ..style.height = "100%"
       ..allowFullscreen = widget.webSpecificParams.webAllowFullscreenContent;
 
     widget.webSpecificParams.additionalSandboxOptions.forEach(


### PR DESCRIPTION
There was a Correction of the message displayed in the console log about style.width and style.height:

```
Height of Platform View type: [_iframe_a275e4a5_5087_4376_beec_3ed898ee3746] may not be set. Defaulting to `height: 100%`.
Set `style.height` to any appropriate value to stop this message.
Width of Platform View type: [_iframe_a275e4a5_5087_4376_beec_3ed898ee3746] may not be set. Defaulting to `width: 100%`.
Set `style.width` to any appropriate value to stop this message.
```