### PR TITLE
Bug fix `callJsMethod`: Encode/decode JSON when passing data between languages

### DIFF
--- a/lib/src/controller/impl/mobile.dart
+++ b/lib/src/controller/impl/mobile.dart
@@ -1,4 +1,6 @@
 import 'dart:async' show Future;
+import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
@@ -127,9 +129,17 @@ class WebViewXController extends ChangeNotifier
 
     // (MOBILE ONLY) Unquotes response if necessary
     //
-    // In the mobile version responses from Js to Dart come wrapped in single quotes (')
-    // The web works fine because it is already into it's native environment
-    return HtmlUtils.unQuoteJsResponseIfNeeded(result);
+    // The web works fine because it is already into its native environment
+    // but on mobile we need to parse the result
+    if (Platform.isAndroid) {
+      // On Android `result` will be JSON, so we decode it
+      return json.decode(result);
+    } else {
+      /// TODO: make sure this works on iOS
+      // In the iOS version responses from JS to Dart come wrapped in single quotes (')
+      // Note that the supported types are more limited because of connector.evaluateJavascript
+      return HtmlUtils.unQuoteJsResponseIfNeeded(result);
+    }
   }
 
   /// This function allows you to evaluate 'raw' javascript (e.g: 2+2)

--- a/lib/src/utils/html_utils.dart
+++ b/lib/src/utils/html_utils.dart
@@ -134,7 +134,10 @@ class HtmlUtils {
     }
 
     for (final param in params) {
-      args.write(addSingleQuotes(param.toString()));
+      // Encode JSON from param
+      // For example, strings will be encoded so JavaScript reads them exactly
+      // as on Dart
+      args.write(json.encode(param));
       args.write(',');
     }
 
@@ -142,11 +145,6 @@ class HtmlUtils {
     final function = '$name($noEndingCommaArgs)';
 
     return function;
-  }
-
-  /// Adds single quotes to the param
-  static String addSingleQuotes(String data) {
-    return "'$data'";
   }
 
   /// Embeds js in the HTML source at the specified position


### PR DESCRIPTION
Fixes #76 

This should also allow passing maps, lists, ints, and doubles between languages but only on Android.

On iOS, it's possible to pass them as parameters to JS functions. But returning lists and maps from JS to Dart will return odd strings generated by Swift/ObjC. I decided to keep the old (but not buggy with strings anymore) behavior here, because type information is lost (i.e. it doesn't distinguish between a 42 and a '42').

https://pub.dev/documentation/webview_flutter/latest/webview_flutter/WebViewController/evaluateJavascript.html:

![image](https://user-images.githubusercontent.com/24363938/178089956-628844af-0b37-47e7-b664-fdcaccba4c25.png)
