### PR TITLE
Allow for a custom BypassProxy class to override how a page source is fetched.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3
+
+- (web) A custom BypassProxy can now also override the way a page is fetched. This includes the ability to use custom protocols or apis instead of a standard http request.
+
 ## 0.2.1
 
 - Breaking change

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -101,21 +101,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   pedantic:
     dependency: transitive
     description:
@@ -176,7 +183,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.9"
   typed_data:
     dependency: transitive
     description:
@@ -197,7 +204,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   webview_flutter:
     dependency: transitive
     description:
@@ -213,5 +220,5 @@ packages:
     source: path
     version: "0.2.1"
 sdks:
-  dart: ">=2.13.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/lib/src/utils/web_url_bypass_proxy.dart
+++ b/lib/src/utils/web_url_bypass_proxy.dart
@@ -1,5 +1,9 @@
+import 'package:http/http.dart' as http;
+
 /// Proxy which will be used to fetch page sources in the [SourceType.urlBypass] mode.
 abstract class BypassProxy {
+  const BypassProxy();
+
   /// Builds the proxied url
   String buildProxyUrl(String pageUrl);
 
@@ -12,10 +16,30 @@ abstract class BypassProxy {
     CodeTabsBypassProxy(),
     WeCorsAnyWhereProxy(),
   ];
+
+  Future<String> fetchPageSource({
+    required String method,
+    required String url,
+    Map<String, String>? headers,
+    Object? body,
+  }) async {
+    final proxiedUri = Uri.parse(buildProxyUrl(Uri.encodeFull(url)));
+
+    Future<http.Response> request;
+
+    if (method == 'get') {
+      request = http.get(proxiedUri, headers: headers);
+    } else {
+      request = http.post(proxiedUri, headers: headers, body: body);
+    }
+
+    final response = await request;
+    return extractPageSource(response.body);
+  }
 }
 
 /// cors.bridged.cc proxy
-class BridgedBypassProxy implements BypassProxy {
+class BridgedBypassProxy extends BypassProxy {
   const BridgedBypassProxy();
 
   @override
@@ -30,7 +54,7 @@ class BridgedBypassProxy implements BypassProxy {
 }
 
 /// api.codetabs.com proxy
-class CodeTabsBypassProxy implements BypassProxy {
+class CodeTabsBypassProxy extends BypassProxy {
   const CodeTabsBypassProxy();
 
   @override
@@ -45,7 +69,7 @@ class CodeTabsBypassProxy implements BypassProxy {
 }
 
 /// we-cors-anywhere.herokuapp.com proxy
-class WeCorsAnyWhereProxy implements BypassProxy {
+class WeCorsAnyWhereProxy extends BypassProxy {
   const WeCorsAnyWhereProxy();
 
   @override

--- a/lib/src/view/impl/web.dart
+++ b/lib/src/view/impl/web.dart
@@ -5,7 +5,6 @@ import 'dart:js' as js;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 
 import 'package:webviewx/src/utils/dart_ui_fix.dart' as ui;
@@ -549,19 +548,13 @@ class _WebViewXState extends State<WebViewX> {
       final proxy = proxyList[i];
       _debugLog('Using proxy: ${proxy.runtimeType}');
 
-      final proxiedUri = Uri.parse(proxy.buildProxyUrl(Uri.encodeFull(url)));
-
-      Future<http.Response> request;
-
-      if (method == 'get') {
-        request = http.get(proxiedUri, headers: headers);
-      } else {
-        request = http.post(proxiedUri, headers: headers, body: body);
-      }
-
       try {
-        final response = await request;
-        return proxy.extractPageSource(response.body);
+        return proxy.fetchPageSource(
+          method: method,
+          url: url,
+          headers: headers,
+          body: body,
+        );
       } catch (e) {
         _debugLog(
           'Failed to fetch the page at $url from proxy ${proxy.runtimeType}.',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -94,21 +94,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: "direct main"
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   pedantic:
     dependency: transitive
     description:
@@ -169,7 +176,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.9"
   typed_data:
     dependency: transitive
     description:
@@ -190,7 +197,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   webview_flutter:
     dependency: "direct main"
     description:
@@ -199,5 +206,5 @@ packages:
     source: hosted
     version: "2.0.13"
 sdks:
-  dart: ">=2.13.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: webviewx
 description: A feature-rich cross-platform webview using webview_flutter for
   mobile and iframe for web. JS interop-ready.
 homepage: https://github.com/adrianflutur/webviewx
-version: 0.2.1
+version: 0.2.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
This PR allows custom BypassProxies to also override the way a page is fetched, i.e. via a custom protocol or api.

### Does this PR change anything for users only using defaults?

No, if you only use the default `BypassProxy` classes, nothing has changed.

### What has changed?

While using this package, I wanted to connect to a custom proxy instance via a protocol that would require to transform the http request.
The previous implementation of `BypassProxy` only allowed to specify a `proxyUrl` but assumed that the remote proxy instance would communicate via standard http requests.

To address this use case, the implementation of fetching the corresponding `pageSource` of a `pageUrl` can now be overridden in a custom `BypassProxy` subclass.
However, the default implementation still assumes the remote proxy instance to communicate via basic http.

As an andditional use case: this change would also allow a custom `BypassProxy` to implement their own caching.