### PR TITLE
Upgrade packages and linter fixes

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:lint/analysis_options_package.yaml
+include: package:flutter_lints/flutter.yaml
 linter:
   rules:
     # Disable

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:lint/analysis_options_package.yaml
+include: package:flutter_lints/flutter.yaml
 linter:
   rules:
     # Disable

--- a/example/lib/helpers.dart
+++ b/example/lib/helpers.dart
@@ -14,7 +14,7 @@ void showAlertDialog(String content, BuildContext context) {
       child: AlertDialog(
         content: Text(content),
         actions: [
-          TextButton(
+          ElevatedButton(
             onPressed: Navigator.of(context).pop,
             child: const Text('Close'),
           ),

--- a/example/lib/webview_page.dart
+++ b/example/lib/webview_page.dart
@@ -11,10 +11,10 @@ class WebViewXPage extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  _WebViewXPageState createState() => _WebViewXPageState();
+  WebViewXPageState createState() => WebViewXPageState();
 }
 
-class _WebViewXPageState extends State<WebViewXPage> {
+class WebViewXPageState extends State<WebViewXPage> {
   late WebViewXController webviewController;
   final initialContent =
       '<h4> This is some hardcoded HTML code embedded inside the webview <h4> <h2> Hello world! <h2>';
@@ -59,7 +59,7 @@ class _WebViewXPageState extends State<WebViewXPage> {
               ),
               Expanded(
                 child: Scrollbar(
-                  isAlwaysShown: true,
+                  thumbVisibility: true,
                   child: SizedBox(
                     width: min(screenSize.width * 0.8, 512),
                     child: ListView(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.1"
   charcode:
     dependency: transitive
     description:
@@ -35,14 +35,14 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   crypto:
     dependency: transitive
     description:
@@ -63,12 +63,19 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -80,7 +87,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.3"
+    version: "0.13.5"
   http_parser:
     dependency: transitive
     description:
@@ -88,48 +95,55 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
-  lint:
-    dependency: "direct dev"
+  lints:
+    dependency: transitive
     description:
-      name: lint
+      name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "2.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.12"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
-  pedantic:
+    version: "1.8.2"
+  plugin_platform_interface:
     dependency: transitive
     description:
-      name: pedantic
+      name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.11.0"
+    version: "2.1.3"
   pointer_interceptor:
     dependency: transitive
     description:
       name: pointer_interceptor
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.0+1"
+    version: "0.9.3+3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -141,7 +155,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -162,21 +176,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.12"
   typed_data:
     dependency: transitive
     description:
@@ -190,28 +204,49 @@ packages:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.4"
+    version: "3.0.7"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   webview_flutter:
     dependency: transitive
     description:
       name: webview_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.13"
+    version: "4.0.2"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.2.1"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.2"
   webviewx:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.2.1"
+    version: "0.3.0"
 sdks:
-  dart: ">=2.13.0 <3.0.0"
-  flutter: ">=2.0.0"
+  dart: ">=2.17.0 <3.0.0"
+  flutter: ">=3.3.10"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -218,28 +218,28 @@ packages:
       name: webview_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.2"
+    version: "3.0.4"
   webview_flutter_android:
     dependency: transitive
     description:
       name: webview_flutter_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.1"
+    version: "2.10.4"
   webview_flutter_platform_interface:
     dependency: transitive
     description:
       name: webview_flutter_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "1.9.5"
   webview_flutter_wkwebview:
     dependency: transitive
     description:
       name: webview_flutter_wkwebview
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "2.9.5"
   webviewx:
     dependency: "direct main"
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,10 +3,11 @@ description: A new Flutter project.
 
 publish_to: "none"
 
-version: 1.0.0+1
+version: 1.0.0+2
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.13.0 <3.0.0"
+  flutter: 3.3.10
 
 dependencies:
   cupertino_icons: ^1.0.3
@@ -19,7 +20,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  lint: ^1.5.3
+  flutter_lints: ^2.0.1
 
 flutter:
   uses-material-design: true

--- a/lib/src/controller/impl/mobile.dart
+++ b/lib/src/controller/impl/mobile.dart
@@ -3,11 +3,8 @@ import 'dart:async' show Future;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:webview_flutter/webview_flutter.dart' as wf;
-import 'package:webviewx/src/utils/html_utils.dart';
-import 'package:webviewx/src/utils/source_type.dart';
-import 'package:webviewx/src/utils/utils.dart';
-
 import 'package:webviewx/src/controller/interface.dart' as i;
+import 'package:webviewx/src/utils/utils.dart';
 
 /// Mobile implementation
 class WebViewXController extends ChangeNotifier
@@ -80,10 +77,10 @@ class WebViewXController extends ChangeNotifier
     bool fromAssets = false,
   }) async {
     if (fromAssets) {
-      final _content = await rootBundle.loadString(content);
+      final contentFromAssets = await rootBundle.loadString(content);
 
       value = WebViewContent(
-        source: _content,
+        source: contentFromAssets,
         sourceType: sourceType,
         headers: headers,
       );
@@ -121,7 +118,7 @@ class WebViewXController extends ChangeNotifier
   ) async {
     // This basically will transform a "raw" call (evaluateJavascript)
     // into a little bit more "typed" call, that is - calling a method.
-    final result = await connector.evaluateJavascript(
+    final result = await connector.runJavascriptReturningResult(
       HtmlUtils.buildJsFunction(name, params),
     );
 
@@ -144,7 +141,7 @@ class WebViewXController extends ChangeNotifier
     String rawJavascript, {
     bool inGlobalContext = false, // NO-OP HERE
   }) {
-    return connector.evaluateJavascript(rawJavascript);
+    return connector.runJavascriptReturningResult(rawJavascript);
   }
 
   /// Returns the current content

--- a/lib/src/controller/impl/web.dart
+++ b/lib/src/controller/impl/web.dart
@@ -4,12 +4,10 @@ import 'dart:js' as js;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
+import 'package:webviewx/src/controller/interface.dart' as i;
 import 'package:webviewx/src/utils/logger.dart';
-import 'package:webviewx/src/utils/source_type.dart';
 import 'package:webviewx/src/utils/utils.dart';
 import 'package:webviewx/src/utils/web_history.dart';
-
-import 'package:webviewx/src/controller/interface.dart' as i;
 
 /// Web implementation
 class WebViewXController extends ChangeNotifier
@@ -89,10 +87,10 @@ class WebViewXController extends ChangeNotifier
     WebViewContent newContent;
 
     if (fromAssets) {
-      final _contentFromAssets = await rootBundle.loadString(content);
+      final contentFromAssets = await rootBundle.loadString(content);
 
       newContent = WebViewContent(
-        source: _contentFromAssets,
+        source: contentFromAssets,
         sourceType: sourceType,
         headers: headers,
         webPostRequestBody: body,

--- a/lib/src/utils/embedded_js_content.dart
+++ b/lib/src/utils/embedded_js_content.dart
@@ -79,6 +79,6 @@ class EmbeddedJsContent {
           js != null || (js == null && mobileJs != null && webJs != null),
           'Choose whether to use globally available js (like console.log), '
           'or platform specific(functions, callbacks, etc; For this, you must fill in '
-          'the coresponding function for all platforms)',
+          'the corresponding function for all platforms)',
         );
 }

--- a/lib/src/utils/html_utils.dart
+++ b/lib/src/utils/html_utils.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:typed_data';
+
 import 'package:path/path.dart' as p;
 import 'package:uuid/uuid.dart';
 import 'package:webviewx/src/utils/constants.dart';
@@ -17,12 +18,13 @@ enum EmbedPosition {
 class HtmlUtils {
   /// Checks if the source looks like HTML
   static bool isFullHtmlPage(String src) {
-    final _src = src.trim().toLowerCase();
-    return _src.startsWith(RegExp('<!DOCTYPE html>', caseSensitive: false)) &&
+    final trimmedSrc = src.trim().toLowerCase();
+    return trimmedSrc
+            .startsWith(RegExp('<!DOCTYPE html>', caseSensitive: false)) &&
         // I didn't forget the closing bracket here.
         // Html opening tag may also have some random attributes.
-        _src.contains(RegExp('<html', caseSensitive: false)) &&
-        _src.contains(RegExp('</html>', caseSensitive: false));
+        trimmedSrc.contains(RegExp('<html', caseSensitive: false)) &&
+        trimmedSrc.contains(RegExp('</html>', caseSensitive: false));
   }
 
   /// Wraps markup in HTML tags
@@ -54,14 +56,14 @@ class HtmlUtils {
     bool encodeHtml = false,
     String? windowDisambiguator,
   }) {
-    var _src = src;
+    var trimmedSrc = src;
 
-    if (!isFullHtmlPage(_src)) {
-      _src = wrapHtml(_src, windowDisambiguator);
+    if (!isFullHtmlPage(trimmedSrc)) {
+      trimmedSrc = wrapHtml(trimmedSrc, windowDisambiguator);
     }
 
     if (forWeb) {
-      _src = embedWebIframeJsConnector(_src, windowDisambiguator!);
+      trimmedSrc = embedWebIframeJsConnector(trimmedSrc, windowDisambiguator!);
     }
 
     if (jsContent.isNotEmpty) {
@@ -77,14 +79,14 @@ class HtmlUtils {
           }
         }
       }
-      _src = embedJsInHtmlSource(_src, jsContentStrings);
+      trimmedSrc = embedJsInHtmlSource(trimmedSrc, jsContentStrings);
     }
 
     if (encodeHtml) {
-      _src = encodeHtmlToURI(_src);
+      trimmedSrc = encodeHtmlToURI(trimmedSrc);
     }
 
-    return _src;
+    return trimmedSrc;
   }
 
   /// Encodes HTML to URI

--- a/lib/src/utils/web_specific_params.dart
+++ b/lib/src/utils/web_specific_params.dart
@@ -1,5 +1,3 @@
-import 'package:webviewx/src/utils/css_loader.dart';
-import 'package:webviewx/src/utils/source_type.dart';
 import 'package:webviewx/src/utils/utils.dart';
 
 /// Parameters specific to the web version.

--- a/lib/src/view/impl/facade.dart
+++ b/lib/src/view/impl/facade.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:webviewx/src/utils/utils.dart';
 import 'package:webviewx/src/controller/interface.dart' as ctrl_interface;
+import 'package:webviewx/src/utils/utils.dart';
 import 'package:webviewx/src/view/interface.dart' as view_interface;
 
 /// Facade class
@@ -30,7 +30,7 @@ class WebViewX extends StatelessWidget implements view_interface.WebViewX {
   @override
   final double height;
 
-  /// Callback which returns a referrence to the [WebViewXController]
+  /// Callback which returns a reference to the [WebViewXController]
   /// being created.
   @override
   final Function(ctrl_interface.WebViewXController controller)?

--- a/lib/src/view/impl/io.dart
+++ b/lib/src/view/impl/io.dart
@@ -1,15 +1,12 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:webviewx/src/utils/utils.dart';
-
-import 'package:webviewx/src/view/interface.dart' as view_interface;
 import 'package:webviewx/src/controller/interface.dart' as ctrl_interface;
-
+import 'package:webviewx/src/utils/utils.dart';
 import 'package:webviewx/src/view/impl/mobile.dart' as mobile;
+import 'package:webviewx/src/view/interface.dart' as view_interface;
 
 /// IO implementation
 ///
-/// Will build the coresponding widget for the current IO platform
+/// Will build the corresponding widget for the current IO platform
 class WebViewX extends StatelessWidget implements view_interface.WebViewX {
   /// Initial content
   @override
@@ -36,7 +33,7 @@ class WebViewX extends StatelessWidget implements view_interface.WebViewX {
   @override
   final double height;
 
-  /// Callback which returns a referrence to the [WebViewXController]
+  /// Callback which returns a reference to the [WebViewXController]
   /// being created.
   @override
   final Function(ctrl_interface.WebViewXController controller)?

--- a/lib/src/view/impl/mobile.dart
+++ b/lib/src/view/impl/mobile.dart
@@ -1,16 +1,13 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:webviewx/src/utils/utils.dart';
-
 import 'package:webview_flutter/platform_interface.dart' as wf_pi;
 import 'package:webview_flutter/webview_flutter.dart' as wf;
-
-import 'package:webviewx/src/view/interface.dart' as view_interface;
-import 'package:webviewx/src/controller/interface.dart' as ctrl_interface;
 import 'package:webviewx/src/controller/impl/mobile.dart';
+import 'package:webviewx/src/controller/interface.dart' as ctrl_interface;
+import 'package:webviewx/src/utils/utils.dart';
+import 'package:webviewx/src/view/interface.dart' as view_interface;
 
 /// Mobile implementation
 class WebViewX extends StatefulWidget implements view_interface.WebViewX {
@@ -39,7 +36,7 @@ class WebViewX extends StatefulWidget implements view_interface.WebViewX {
   @override
   final double height;
 
-  /// Callback which returns a referrence to the [WebViewXController]
+  /// Callback which returns a reference to the [WebViewXController]
   /// being created.
   @override
   final Function(ctrl_interface.WebViewXController controller)?
@@ -130,10 +127,10 @@ class WebViewX extends StatefulWidget implements view_interface.WebViewX {
   }) : super(key: key);
 
   @override
-  _WebViewXState createState() => _WebViewXState();
+  WebViewXState createState() => WebViewXState();
 }
 
-class _WebViewXState extends State<WebViewX> {
+class WebViewXState extends State<WebViewX> {
   late wf.WebViewController originalWebViewController;
   late WebViewXController webViewXController;
 
@@ -211,7 +208,7 @@ class _WebViewXState extends State<WebViewX> {
       originalWebViewController = webViewController;
 
       webViewXController.connector = originalWebViewController;
-      // Calls onWebViewCreated to pass the refference upstream
+      // Calls onWebViewCreated to pass the reference upstream
       if (widget.onWebViewCreated != null) {
         widget.onWebViewCreated!(webViewXController);
       }

--- a/lib/src/view/impl/web.dart
+++ b/lib/src/view/impl/web.dart
@@ -3,17 +3,15 @@ import 'dart:convert';
 import 'dart:html' as html;
 import 'dart:js' as js;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:pointer_interceptor/pointer_interceptor.dart';
-
-import 'package:webviewx/src/utils/dart_ui_fix.dart' as ui;
-import 'package:webviewx/src/utils/constants.dart';
-import 'package:webviewx/src/utils/logger.dart';
-import 'package:webviewx/src/utils/utils.dart';
 import 'package:webviewx/src/controller/impl/web.dart';
 import 'package:webviewx/src/controller/interface.dart' as ctrl_interface;
+import 'package:webviewx/src/utils/constants.dart';
+import 'package:webviewx/src/utils/dart_ui_fix.dart' as ui;
+import 'package:webviewx/src/utils/logger.dart';
+import 'package:webviewx/src/utils/utils.dart';
 import 'package:webviewx/src/view/interface.dart' as view_interface;
 
 /// Web implementation
@@ -43,7 +41,7 @@ class WebViewX extends StatefulWidget implements view_interface.WebViewX {
   @override
   final double height;
 
-  /// Callback which returns a referrence to the [WebViewXController]
+  /// Callback which returns a reference to the [WebViewXController]
   /// being created.
   @override
   final Function(ctrl_interface.WebViewXController controller)?
@@ -134,10 +132,10 @@ class WebViewX extends StatefulWidget implements view_interface.WebViewX {
   }) : super(key: key);
 
   @override
-  _WebViewXState createState() => _WebViewXState();
+  WebViewXState createState() => WebViewXState();
 }
 
-class _WebViewXState extends State<WebViewX> {
+class WebViewXState extends State<WebViewX> {
   late html.IFrameElement iframe;
   late String iframeViewType;
   late StreamSubscription iframeOnLoadSubscription;
@@ -195,7 +193,7 @@ class _WebViewXState extends State<WebViewX> {
       ..addIgnoreGesturesListener(_handleIgnoreGesturesChange);
   }
 
-  // Keep js "window" object referrence, so we can call functions on it later.
+  // Keep js "window" object reference, so we can call functions on it later.
   // This happens only if we use HTML (because you can't alter the source code
   // of some other webpage that you pass in using the URL param)
   //

--- a/lib/src/view/interface.dart
+++ b/lib/src/view/interface.dart
@@ -1,5 +1,5 @@
-import 'package:webviewx/src/utils/utils.dart';
 import 'package:webviewx/src/controller/interface.dart';
+import 'package:webviewx/src/utils/utils.dart';
 
 /// Interface for widget
 abstract class WebViewX {
@@ -23,7 +23,7 @@ abstract class WebViewX {
   /// Widget height
   final double height;
 
-  /// Callback which returns a referrence to the [IWebViewXController]
+  /// Callback which returns a reference to the [IWebViewXController]
   /// being created.
   final Function(WebViewXController controller)? onWebViewCreated;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.1"
   charcode:
     dependency: transitive
     description:
@@ -35,14 +35,14 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   crypto:
     dependency: transitive
     description:
@@ -56,12 +56,19 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -73,7 +80,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.3"
+    version: "0.13.5"
   http_parser:
     dependency: transitive
     description:
@@ -81,48 +88,55 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
-  lint:
-    dependency: "direct dev"
+  lints:
+    dependency: transitive
     description:
-      name: lint
+      name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "2.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.12"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.8.0"
   path:
     dependency: "direct main"
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
-  pedantic:
+    version: "1.8.2"
+  plugin_platform_interface:
     dependency: transitive
     description:
-      name: pedantic
+      name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.11.1"
+    version: "2.1.3"
   pointer_interceptor:
     dependency: "direct main"
     description:
       name: pointer_interceptor
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.0+1"
+    version: "0.9.3+3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -134,7 +148,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -155,21 +169,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.12"
   typed_data:
     dependency: transitive
     description:
@@ -183,21 +197,42 @@ packages:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.4"
+    version: "3.0.7"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   webview_flutter:
     dependency: "direct main"
     description:
       name: webview_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.13"
+    version: "4.0.2"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.2.1"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.2"
 sdks:
-  dart: ">=2.13.0 <3.0.0"
-  flutter: ">=2.0.0"
+  dart: ">=2.17.0 <3.0.0"
+  flutter: ">=3.3.10"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -211,28 +211,28 @@ packages:
       name: webview_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.2"
+    version: "3.0.4"
   webview_flutter_android:
     dependency: transitive
     description:
       name: webview_flutter_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.1"
+    version: "2.10.4"
   webview_flutter_platform_interface:
     dependency: transitive
     description:
       name: webview_flutter_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "1.9.5"
   webview_flutter_wkwebview:
     dependency: transitive
     description:
       name: webview_flutter_wkwebview
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "2.9.5"
 sdks:
   dart: ">=2.17.0 <3.0.0"
   flutter: ">=3.3.10"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   path: ^1.8.2
   pointer_interceptor: ^0.9.3+3
   uuid: ^3.0.7
-  webview_flutter: ^4.0.2
+  webview_flutter: ^3.0.4
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,22 +2,22 @@ name: webviewx
 description: A feature-rich cross-platform webview using webview_flutter for
   mobile and iframe for web. JS interop-ready.
 homepage: https://github.com/adrianflutur/webviewx
-version: 0.2.1
+version: 0.3.0
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.17.0"
+  sdk: ">=2.13.0 <3.0.0"
+  flutter: 3.3.10
 
 dependencies:
   flutter:
     sdk: flutter
-  http: ^0.13.3
-  path: ^1.8.0
-  pointer_interceptor: ^0.9.0+1
-  uuid: ^3.0.4
-  webview_flutter: ^2.0.13
+  http: ^0.13.5
+  path: ^1.8.2
+  pointer_interceptor: ^0.9.3+3
+  uuid: ^3.0.7
+  webview_flutter: ^4.0.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  lint: ^1.6.0
+  flutter_lints: ^2.0.1


### PR DESCRIPTION
- This PR:
  - Upgrades `webview_flutter` to v3
  - Upgrades other packages to highest patch version
  - Sets flutter SDK to latest stable version and make appropriate changes throughout
  - Fixes misc. typos and linter errors
  - Switch to flutter_lints (flutter team recommends)